### PR TITLE
Added dummy routes for the initial development of the UI screens

### DIFF
--- a/frontend/src/containers/App/index.js
+++ b/frontend/src/containers/App/index.js
@@ -1,32 +1,46 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect } from "react";
 import { Router } from "@reach/router";
-import { useDispatch } from 'redux-react-hook';
-import { bootstrap as bootstrapAction } from 'store/modules/app/actions';
+import { useDispatch } from "redux-react-hook";
+import { bootstrap as bootstrapAction } from "store/modules/app/actions";
 
-import Home from 'pages/Home';
-import Dashboard from 'pages/Dashboard';
-import Login from 'pages/Auth/Login';
-import SignUp from 'pages/Auth/SignUp';
-import Main from 'containers/Layouts/Main';
-import Full from 'containers/Layouts/Full';
+import Home from "pages/Home";
+import Dashboard from "pages/Dashboard";
+import Login from "pages/Auth/Login";
+import SignUp from "pages/Auth/SignUp";
+import Main from "containers/Layouts/Main";
+import Full from "containers/Layouts/Full";
+import Portal from "containers/Layouts/Portal";
+import CreateWorkflow from "pages/Portal/CreateWorkflow";
+import IgniteCluster from "pages/Portal/IgniteCluster";
+import Conformance from "pages/Portal/Conformance";
+import Schedule from "pages/Portal/Schedule";
 
 export default function App() {
-  const dispatch = useDispatch();
-  const bootstrap = useCallback(() => dispatch(bootstrapAction()));
-  useEffect(() => {
-    bootstrap();
-  });
+	const dispatch = useDispatch();
+	const bootstrap = useCallback(() => dispatch(bootstrapAction()));
+	useEffect(() => {
+		bootstrap();
+	});
 
-  return (
-    <Router>
-      <Home path="/" />
-      <Main path="/app">
-        <Dashboard path="dashboard" />
-      </Main>
-      <Full path="/auth">
-        <Login path="login" />
-        <SignUp path="signup" />
-      </Full>
-    </Router>
-  );
+	return (
+		<Router>
+			<Home path="/" />
+			<Main path="/app">
+				<Dashboard path="dashboard" />
+			</Main>
+			<Full path="/auth">
+				<Login path="login" />
+				<SignUp path="signup" />
+			</Full>
+			{/* Dummy Routes */}
+			<Portal path="/portal">
+				<Home path="home" />
+				<Dashboard path="dashboard" />
+				<CreateWorkflow path="workflow/create" />
+				<IgniteCluster path="workflow/create/ignite" />
+				<Conformance path="workflow/create/ignite/conformance" />
+				<Schedule path="workflow/create/ignite/conformance/schedule" />
+			</Portal>
+		</Router>
+	);
 }

--- a/frontend/src/containers/Layouts/Portal.js
+++ b/frontend/src/containers/Layouts/Portal.js
@@ -1,0 +1,15 @@
+import React from "react";
+import classNames from "classnames";
+import styles from "./Layouts.module.scss";
+
+export default function Portal({ children }) {
+	return (
+		<div
+			className={classNames(
+				styles.main,
+				"h-screen w-screen flex items-center justify-center bg-grey-darkest"
+			)}>
+			{children}
+		</div>
+	);
+}

--- a/frontend/src/pages/Portal/Conformance/index.js
+++ b/frontend/src/pages/Portal/Conformance/index.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function Conformance() {
+	return (
+		<div>
+			<h3>Portal : Conformance </h3>
+		</div>
+	);
+}

--- a/frontend/src/pages/Portal/CreateWorkflow/index.js
+++ b/frontend/src/pages/Portal/CreateWorkflow/index.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function CreateWorkFLow() {
+	return (
+		<div>
+			<h3>Portal : CreateWorkFLow </h3>
+		</div>
+	);
+}

--- a/frontend/src/pages/Portal/IgniteCluster/index.js
+++ b/frontend/src/pages/Portal/IgniteCluster/index.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function IgniteCluster() {
+	return (
+		<div>
+			<h3>Portal : Ignite Clusters </h3>
+		</div>
+	);
+}

--- a/frontend/src/pages/Portal/Schedule/index.js
+++ b/frontend/src/pages/Portal/Schedule/index.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function Schedule() {
+	return (
+		<div>
+			<h3>Portal : Schedule </h3>
+		</div>
+	);
+}


### PR DESCRIPTION
Signed-off-by: amityt <amitkumar.das@mayadata.io>

The UI screens can be viewed here:
https://www.figma.com/file/6nvMqOkwlLDPU48EdYk6j2/Repute%2FLitmus-Styles?node-id=61%3A2

The name of the routes are taken from the breadcrumbs of each screen. 
Example : CreateWorkflow is for Creating a traget cluster
IgniteCluster is for choosing a Workflow and so on.

These are just the dummy routes for the development of the UI screens. The routes can be changed once we integrate the screens with the backend server. 